### PR TITLE
Add Arguments to main() so we can actually change network without recompilation

### DIFF
--- a/Greedy/Source/TNA/TNADriver/TNADriver.cpp
+++ b/Greedy/Source/TNA/TNADriver/TNADriver.cpp
@@ -57,11 +57,19 @@ int TestGreedy( const string &path, const string &name)
 	
 }
 
-int main()
+int main(int argc, char* argv[])
 {
-	string cs="ChicagoSketch";
-	string sf = "SiouxFalls";
+    std::string networkPath, networkName;
 
-	
-	TestGreedy("..\\..\\..\\Network\\cs\\",cs); //"..\\..\\..\\Network\\sf\\",sf
+    if (argc > 2) {
+        networkPath = argv[1];   // Path containing the TNTP network files e.g., "..\\..\\Network\\sf\\"
+        networkName = argv[2];   // Name of the TNTP network files e.g., "SiouxFalls" it will automatically search for _node, _net and _trips
+    } else {
+        // fallback default
+        networkPath = "..\\..\\Network\\cs\\"; // in current GIT structure, the network folder is in greedy\network, that is 2 levels (bin\x64) away not 3 levels away
+        networkName = "ChicagoSketch";
+    }
+
+    TestGreedy(networkPath, networkName);
+    return 0;
 };


### PR DESCRIPTION
Attempt to make the build exe take extra command line argument to specify network path and network file.
- due to VS2012 build i cannot get the vs-solution to run (conflict in mysql++.h common.h means snprintf macro redefinition blocks build)
- Removal of the snprintf gives alot more errors
- Requesting Author of Greedy to suggest a fix for this or build using VS2012